### PR TITLE
Upgrade the base image to Ubuntu 16.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:16.04
 MAINTAINER Yuji Yamamoto <y.yammt+github -a-t- gmail.com>
 
 ENV JUBATUS_CORE_URL=https://github.com/jubatus/jubatus_core.git \


### PR DESCRIPTION
The latest version of Jubatus supports Ubuntu 16.04.
So I upgrade the base image for Dockerfile.